### PR TITLE
fix: updates for the new discord.js API

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -108,7 +108,7 @@ class Bot {
     // Extract id and token from Webhook urls and connect.
     _.forOwn(this.webhookOptions, (url, channel) => {
       const [id, token] = url.split('/').slice(-2);
-      const client = new discord.WebhookClient(id, token);
+      const client = new discord.WebhookClient({ id, token });
       this.webhooks[channel] = {
         id,
         client
@@ -283,7 +283,7 @@ class Bot {
   parseText(message) {
     const usedFields = ['title', 'description', 'fields', 'image', 'footer'];
     let embed = '';
-    if (message.embeds.length) {
+    if (message.embeds?.length) {
       usedFields.forEach((key) => {
         if (message.embeds[0][key]) {
           if (key === 'fields') {
@@ -318,6 +318,8 @@ class Bot {
     }, message.content);
 
     text = `${text}\n${embed}`;
+
+    text = text.replace(/[\r\n]+/g, ' ');
     text = text.trim();
 
     return text
@@ -448,7 +450,7 @@ class Bot {
       } else if (discordChannelName.startsWith('#')) {
         discordChannel = this.discord.channels.cache
           // unclear if this UNKNOWN is a test bug or happens in the real world
-          .filter(c => c.type === 'text' || c.type === 'UNKNOWN')
+          .filter(c => c.type === 'GUILD_TEXT' || c.type === 'text' || c.type === 'UNKNOWN')
           .find(c => c.name === discordChannelName.slice(1));
       }
 
@@ -471,6 +473,7 @@ class Bot {
 
   getDiscordAvatar(nick, channel) {
     const guildMembers = this.findDiscordChannel(channel).guild.members.cache;
+
     const findByNicknameOrUsername = caseSensitive =>
       (member) => {
         if (caseSensitive) {
@@ -547,14 +550,22 @@ class Bot {
     }
 
     const { guild } = discordChannel;
-    const withMentions = withFormat.replace(/@([^\s#]+)#(\d+)/g, (match, username, discriminator) => {
-      // @username#1234 => mention
-      // skips usernames including spaces for ease (they cannot include hashes)
-      // checks case insensitively as Discord does
-      const user = guild.members.cache.find(x =>
+
+    const withMentions = withFormat.replace(/@([^\s#@'"!?,.]+)(?:#(\d+))?/g, (match, username, discriminator) => {
+      const users = guild.members.cache.filter(x =>
+        (Bot.caseComp(x.user.username, username) || Bot.caseComp(x.nickname || '', username))
+        && (!discriminator || x.user.discriminator === discriminator));
+
+      if (users?.size === 1) return users.at(0);
+
+      return match;
+    }).replace(/^\s*([^\s#@'"!?,.]+)(?:#(\d+))?[:,]/, (match, username, discriminator) => {
+      // "user: text" or "user, text" mentions
+      const users = guild.members.cache.filter(x =>
         Bot.caseComp(x.user.username, username)
-        && x.user.discriminator === discriminator);
-      if (user) return user;
+        && (!discriminator || x.user.discriminator === discriminator));
+
+      if (users?.size === 1) return users.at(0);
 
       return match;
     }).replace(/:(\w+):/g, (match, ident) => {
@@ -563,7 +574,7 @@ class Bot {
       if (emoji) return emoji;
 
       return match;
-    }).replace(/#([^\s#@'!?,.]+)/g, (match, channelName) => {
+    }).replace(/#([^\s#@'"!?,.]+)/g, (match, channelName) => {
       // channel names can't contain spaces, #, @, ', !, ?, , or .
       // (based on brief testing. they also can't contain some other symbols,
       // but these seem likely to be common around channel references)
@@ -584,10 +595,11 @@ class Bot {
       }
       const avatarURL = this.getDiscordAvatar(author, channel);
       const username = _.padEnd(author.substring(0, USERNAME_MAX_LENGTH), USERNAME_MIN_LENGTH, '_');
-      webhook.client.send(withMentions, {
+      webhook.client.send({
         username,
         avatarURL,
-        disableMentions: canPingEveryone ? 'none' : 'everyone',
+        content: withMentions,
+        allowedMentions: { parse: ['users', ...(canPingEveryone ? ['roles', 'everyone'] : [])] }
       }).catch(logger.error);
       return;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "commander": "^7.2.0",
-        "discord.js": "^13.8.1",
+        "discord.js": "^13.9.1",
         "irc-colors": "1.5.0",
         "irc-formatting": "1.0.0-rc3",
         "irc-upd": "0.11.0",
@@ -1723,13 +1723,13 @@
       }
     },
     "node_modules/@discordjs/builders": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.14.0.tgz",
-      "integrity": "sha512-+fqLIqa9wN3R+kvlld8sgG0nt04BAZxdCDP4t2qZ9TJsquLWA+xMtT8Waibb3d4li4AQS+IOfjiHAznv/dhHgQ==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.16.0.tgz",
+      "integrity": "sha512-9/NCiZrLivgRub2/kBc0Vm5pMBE5AUdYbdXsLu/yg9ANgvnaJ0bZKTY8yYnLbsEc/LYUP79lEIdC73qEYhWq7A==",
+      "deprecated": "no longer supported",
       "dependencies": {
-        "@sapphire/shapeshift": "^3.1.0",
-        "@sindresorhus/is": "^4.6.0",
-        "discord-api-types": "^0.33.3",
+        "@sapphire/shapeshift": "^3.5.1",
+        "discord-api-types": "^0.36.2",
         "fast-deep-equal": "^3.1.3",
         "ts-mixer": "^6.0.1",
         "tslib": "^2.4.0"
@@ -1737,6 +1737,11 @@
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/@discordjs/builders/node_modules/discord-api-types": {
+      "version": "0.36.3",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.36.3.tgz",
+      "integrity": "sha512-bz/NDyG0KBo/tY14vSkrwQ/n3HKPf87a0WFW/1M9+tXYK+vp5Z5EksawfCWo2zkAc6o7CClc0eff1Pjrqznlwg=="
     },
     "node_modules/@discordjs/collection": {
       "version": "0.7.0",
@@ -1874,32 +1879,25 @@
       "optional": true
     },
     "node_modules/@sapphire/async-queue": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.3.1.tgz",
-      "integrity": "sha512-FFTlPOWZX1kDj9xCAsRzH5xEJfawg1lNoYAA+ecOWJMHOfiZYb1uXOI3ne9U4UILSEPwfE68p3T9wUHwIQfR0g==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.3.2.tgz",
+      "integrity": "sha512-rUpMLATsoAMnlN3gecAcr9Ecnw1vG7zi5Xr+IX22YzRzi1k9PF9vKzoT8RuEJbiIszjcimu3rveqUnvwDopz8g==",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/@sapphire/shapeshift": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.4.0.tgz",
-      "integrity": "sha512-uV+vErdfbxCgnjgcwkPDADlyS40I20L57YPy254LKbRNfLCg4/ymy510aNSGhLhq/dpNU0s1fQnTbI2YAetzsA==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.5.1.tgz",
+      "integrity": "sha512-7JFsW5IglyOIUQI1eE0g6h06D/Far6HqpcowRScgCiLSqTf3hhkPWCWotVTtVycnDCMYIwPeaw6IEPBomKC8pA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash.uniqwith": "^4.5.0"
+      },
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@sindresorhus/is": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -2619,19 +2617,19 @@
       "integrity": "sha512-dvO5M52v7m7Dy96+XUnzXNsQ/0npsYpU6dL205kAtEDueswoz3aU3bh1UMoK4cQmcGtB1YRyLKqp+DXi05lzFg=="
     },
     "node_modules/discord.js": {
-      "version": "13.8.1",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.8.1.tgz",
-      "integrity": "sha512-jOsD+4tEZWWx0RHVyH+FBcqoTrsL+d5Mm5p+ULQOdU0qSaxhLNkWYig+yDHNZoND7nlkXX3qi+BW+gO5erWylg==",
+      "version": "13.9.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.9.1.tgz",
+      "integrity": "sha512-vVKtSw0fT2ifEcCdI7+nfjEY3/wBfyls3L8Qo9uEhbAl1vCSXd7msskGyNIXzKqRUTz0R84UG10e8jmNxKIBLQ==",
       "dependencies": {
-        "@discordjs/builders": "^0.14.0",
+        "@discordjs/builders": "^0.16.0",
         "@discordjs/collection": "^0.7.0",
-        "@sapphire/async-queue": "^1.3.1",
-        "@types/node-fetch": "^2.6.1",
+        "@sapphire/async-queue": "^1.3.2",
+        "@types/node-fetch": "^2.6.2",
         "@types/ws": "^8.5.3",
         "discord-api-types": "^0.33.3",
         "form-data": "^4.0.0",
-        "node-fetch": "^2.6.1",
-        "ws": "^8.7.0"
+        "node-fetch": "^2.6.7",
+        "ws": "^8.8.1"
       },
       "engines": {
         "node": ">=16.6.0",
@@ -4121,6 +4119,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.uniqwith": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqwith/-/lodash.uniqwith-4.5.0.tgz",
+      "integrity": "sha512-7lYL8bLopMoy4CTICbxygAUq6CdRJ36vFc80DucPueUee+d5NBRxz3FdT9Pes/HEx5mPoT9jwnsEJWz1N7uq7Q=="
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -5738,9 +5741,9 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
-      "integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
+      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -7015,16 +7018,22 @@
       }
     },
     "@discordjs/builders": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.14.0.tgz",
-      "integrity": "sha512-+fqLIqa9wN3R+kvlld8sgG0nt04BAZxdCDP4t2qZ9TJsquLWA+xMtT8Waibb3d4li4AQS+IOfjiHAznv/dhHgQ==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.16.0.tgz",
+      "integrity": "sha512-9/NCiZrLivgRub2/kBc0Vm5pMBE5AUdYbdXsLu/yg9ANgvnaJ0bZKTY8yYnLbsEc/LYUP79lEIdC73qEYhWq7A==",
       "requires": {
-        "@sapphire/shapeshift": "^3.1.0",
-        "@sindresorhus/is": "^4.6.0",
-        "discord-api-types": "^0.33.3",
+        "@sapphire/shapeshift": "^3.5.1",
+        "discord-api-types": "^0.36.2",
         "fast-deep-equal": "^3.1.3",
         "ts-mixer": "^6.0.1",
         "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "discord-api-types": {
+          "version": "0.36.3",
+          "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.36.3.tgz",
+          "integrity": "sha512-bz/NDyG0KBo/tY14vSkrwQ/n3HKPf87a0WFW/1M9+tXYK+vp5Z5EksawfCWo2zkAc6o7CClc0eff1Pjrqznlwg=="
+        }
       }
     },
     "@discordjs/collection": {
@@ -7138,19 +7147,18 @@
       "optional": true
     },
     "@sapphire/async-queue": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.3.1.tgz",
-      "integrity": "sha512-FFTlPOWZX1kDj9xCAsRzH5xEJfawg1lNoYAA+ecOWJMHOfiZYb1uXOI3ne9U4UILSEPwfE68p3T9wUHwIQfR0g=="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.3.2.tgz",
+      "integrity": "sha512-rUpMLATsoAMnlN3gecAcr9Ecnw1vG7zi5Xr+IX22YzRzi1k9PF9vKzoT8RuEJbiIszjcimu3rveqUnvwDopz8g=="
     },
     "@sapphire/shapeshift": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.4.0.tgz",
-      "integrity": "sha512-uV+vErdfbxCgnjgcwkPDADlyS40I20L57YPy254LKbRNfLCg4/ymy510aNSGhLhq/dpNU0s1fQnTbI2YAetzsA=="
-    },
-    "@sindresorhus/is": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.5.1.tgz",
+      "integrity": "sha512-7JFsW5IglyOIUQI1eE0g6h06D/Far6HqpcowRScgCiLSqTf3hhkPWCWotVTtVycnDCMYIwPeaw6IEPBomKC8pA==",
+      "requires": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash.uniqwith": "^4.5.0"
+      }
     },
     "@sinonjs/commons": {
       "version": "1.8.3",
@@ -7716,19 +7724,19 @@
       "integrity": "sha512-dvO5M52v7m7Dy96+XUnzXNsQ/0npsYpU6dL205kAtEDueswoz3aU3bh1UMoK4cQmcGtB1YRyLKqp+DXi05lzFg=="
     },
     "discord.js": {
-      "version": "13.8.1",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.8.1.tgz",
-      "integrity": "sha512-jOsD+4tEZWWx0RHVyH+FBcqoTrsL+d5Mm5p+ULQOdU0qSaxhLNkWYig+yDHNZoND7nlkXX3qi+BW+gO5erWylg==",
+      "version": "13.9.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.9.1.tgz",
+      "integrity": "sha512-vVKtSw0fT2ifEcCdI7+nfjEY3/wBfyls3L8Qo9uEhbAl1vCSXd7msskGyNIXzKqRUTz0R84UG10e8jmNxKIBLQ==",
       "requires": {
-        "@discordjs/builders": "^0.14.0",
+        "@discordjs/builders": "^0.16.0",
         "@discordjs/collection": "^0.7.0",
-        "@sapphire/async-queue": "^1.3.1",
-        "@types/node-fetch": "^2.6.1",
+        "@sapphire/async-queue": "^1.3.2",
+        "@types/node-fetch": "^2.6.2",
         "@types/ws": "^8.5.3",
         "discord-api-types": "^0.33.3",
         "form-data": "^4.0.0",
-        "node-fetch": "^2.6.1",
-        "ws": "^8.7.0"
+        "node-fetch": "^2.6.7",
+        "ws": "^8.8.1"
       }
     },
     "doctrine": {
@@ -8842,6 +8850,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "lodash.uniqwith": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqwith/-/lodash.uniqwith-4.5.0.tgz",
+      "integrity": "sha512-7lYL8bLopMoy4CTICbxygAUq6CdRJ36vFc80DucPueUee+d5NBRxz3FdT9Pes/HEx5mPoT9jwnsEJWz1N7uq7Q=="
     },
     "log-symbols": {
       "version": "4.1.0",
@@ -10056,9 +10069,9 @@
       "dev": true
     },
     "ws": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
-      "integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
+      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
       "requires": {}
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "license": "MIT",
   "dependencies": {
     "commander": "^7.2.0",
-    "discord.js": "^13.8.1",
+    "discord.js": "^13.9.1",
     "irc-colors": "1.5.0",
     "irc-formatting": "1.0.0-rc3",
     "irc-upd": "0.11.0",


### PR DESCRIPTION
Update discord.js to 13.9.1.
Pass object to WebhookClient constructor.
Match text channels of type 'GUILD_TEXT'.
Fix parameters to WebhookClient.send().
Make some parsing, formatting and test adjustments for the API changes.

Signed-off-by: Rafael Kitover <rkitover@gmail.com>