### PR TITLE
fix: use _nick_ for IRC parallel ping fix

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -380,7 +380,7 @@ class Bot {
       if (this.parallelPingFix) {
         // Prevent users of both IRC and Discord from
         // being mentioned in IRC when they talk in Discord.
-        displayUsername = `${displayUsername.slice(0, 1)}\u200B${displayUsername.slice(1)}`;
+        displayUsername = `_${displayUsername}_`;
       }
 
       if (this.ircNickColor) {

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -368,7 +368,6 @@ describe('Bot', function () {
 
     const text = 'testmessage';
     const username = 'otherauthor';
-    const brokenNickname = 'o\u200Btherauthor';
     const message = {
       content: text,
       mentions: { users: [] },
@@ -383,8 +382,8 @@ describe('Bot', function () {
     };
 
     this.bot.sendToIRC(message);
-    // Wrap in colors:
-    const expected = `<\u000304${brokenNickname}\u000f> ${text}`;
+    // Wrap in colors and ping fix:
+    const expected = `<\u000304_${username}_\u000f> ${text}`;
     ClientStub.prototype.say.should.have.been.calledWith('#irc', expected);
   });
 


### PR DESCRIPTION
On my terminal the zero-width space becomes an actual space after the
first letter of the Discord nick.

Add a '_' to the beginning and end of the Discord nick instead.

Signed-off-by: Rafael Kitover <rkitover@gmail.com>