### PR TITLE
fix: make chardet and iconv-lite hard deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,10 @@
       "version": "2.9.0",
       "license": "MIT",
       "dependencies": {
+        "chardet": "^1.4.0",
         "commander": "^7.2.0",
         "discord.js": "^13.8.1",
+        "iconv-lite": "^0.6.3",
         "irc-colors": "1.5.0",
         "irc-formatting": "1.0.0-rc3",
         "irc-upd": "0.11.0",
@@ -2341,8 +2343,7 @@
     "node_modules/chardet": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-1.4.0.tgz",
-      "integrity": "sha512-NpwMDdSIprbYx1CLnfbxEIarI0Z+s9MssEgggMNheGM+WD68yOhV7IEA/3r6tr0yTRgQD0HuZJDw32s99i6L+A==",
-      "optional": true
+      "integrity": "sha512-NpwMDdSIprbYx1CLnfbxEIarI0Z+s9MssEgggMNheGM+WD68yOhV7IEA/3r6tr0yTRgQD0HuZJDw32s99i6L+A=="
     },
     "node_modules/check-error": {
       "version": "1.0.2",
@@ -3628,7 +3629,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -5081,8 +5081,7 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "optional": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semver": {
       "version": "6.3.0",
@@ -7498,8 +7497,7 @@
     "chardet": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-1.4.0.tgz",
-      "integrity": "sha512-NpwMDdSIprbYx1CLnfbxEIarI0Z+s9MssEgggMNheGM+WD68yOhV7IEA/3r6tr0yTRgQD0HuZJDw32s99i6L+A==",
-      "optional": true
+      "integrity": "sha512-NpwMDdSIprbYx1CLnfbxEIarI0Z+s9MssEgggMNheGM+WD68yOhV7IEA/3r6tr0yTRgQD0HuZJDw32s99i6L+A=="
     },
     "check-error": {
       "version": "1.0.2",
@@ -8490,7 +8488,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "optional": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
@@ -9557,8 +9554,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "optional": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
       "version": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,10 @@
   },
   "license": "MIT",
   "dependencies": {
+    "chardet": "^1.4.0",
     "commander": "^7.2.0",
     "discord.js": "^13.8.1",
+    "iconv-lite": "^0.6.3",
     "irc-colors": "1.5.0",
     "irc-formatting": "1.0.0-rc3",
     "irc-upd": "0.11.0",


### PR DESCRIPTION
These are needed to handle encoding by the IRC library.

Signed-off-by: Rafael Kitover <rkitover@gmail.com>